### PR TITLE
Fixed calculation bug

### DIFF
--- a/timeagoinwords/services/TimeAgoInWords_FunctionsService.php
+++ b/timeagoinwords/services/TimeAgoInWords_FunctionsService.php
@@ -21,14 +21,14 @@ class TimeAgoInWords_FunctionsService extends BaseApplicationComponent
 		$timezone = $settings->timezone ? $settings->timezone : 'Europe/London';
 		date_default_timezone_set($timezone);
 
-		// get timestamp for datetime
-		$datetime = strtotime($datetime);
+		// get past timestamp
+		$past = $datetime->format('U');
 
 		// get current timestamp
 		$now = strtotime("now");
 
-		// calcluate time difference
-		$distanceInSeconds = $now - $datetime;
+		// calculate time difference
+		$distanceInSeconds = $now - $past;
 		$distanceInMinutes = round($distanceInSeconds / 60);
 
 		if ( $distanceInMinutes <= 1 ) {


### PR DESCRIPTION
This fixes a bug which would miscalculate how much time has passed.

The most important change is on **line 25**... all other changes are aesthetic.

Specifically, `strtotime($datetime)` would accidentally be parsed as _midnight_ on the specified day. Only the date gets rendered via the `__toString` magic method of a DateTime object (which is what `$datetime` is), the actual time gets omitted.
